### PR TITLE
feat: add TypeScript types to frontend files

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect } from 'react'
-import { fetchTargets } from './api.js'
-import Sidebar from './components/Sidebar.jsx'
-import GraphView from './components/GraphView.jsx'
-import ZoomView from './components/ZoomView.jsx'
+import { fetchTargets } from './api'
+import Sidebar from './components/Sidebar'
+import GraphView from './components/GraphView'
+import ZoomView from './components/ZoomView'
+import type { TreeNode, TargetNode, ZoomState } from './types'
 
 export default function App() {
-  const [tree, setTree] = useState(null)
+  const [tree, setTree] = useState<TreeNode[] | null>(null)
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
-  const [activeTarget, setActiveTarget] = useState(null)
-  const [zoomState, setZoomState] = useState(null) // { target, startTs, endTs } | null
+  const [error, setError] = useState<string | null>(null)
+  const [activeTarget, setActiveTarget] = useState<TargetNode | null>(null)
+  const [zoomState, setZoomState] = useState<ZoomState | null>(null)
 
   useEffect(() => {
     fetchTargets()
@@ -19,7 +20,7 @@ export default function App() {
         const first = findFirstTarget(data)
         if (first) setActiveTarget(first)
       })
-      .catch((e) => {
+      .catch((e: Error) => {
         setError(e.message)
         setLoading(false)
       })
@@ -33,24 +34,25 @@ export default function App() {
     }
   }, [activeTarget])
 
-  function handleSelectTarget(target) {
+  function handleSelectTarget(target: TargetNode) {
     setActiveTarget(target)
     setZoomState(null)
   }
 
-  function handleZoom(startTs, endTs) {
+  function handleZoom(startTs: number, endTs: number) {
+    if (!activeTarget) return
     setZoomState({ target: activeTarget, startTs, endTs })
   }
 
-  function handleZoomFromZoom(startTs, endTs) {
-    setZoomState((z) => ({ ...z, startTs, endTs }))
+  function handleZoomFromZoom(startTs: number, endTs: number) {
+    setZoomState((z) => (z ? { ...z, startTs, endTs } : z))
   }
 
   return (
     <div className="app">
       <Sidebar
         tree={tree}
-        activePath={activeTarget?.path}
+        activePath={activeTarget?.path ?? null}
         onSelect={handleSelectTarget}
         loading={loading}
         error={error}
@@ -72,8 +74,8 @@ export default function App() {
   )
 }
 
-function findFirstTarget(items) {
-  for (const item of items) {
+function findFirstTarget(nodes: TreeNode[]): TargetNode | null {
+  for (const item of nodes) {
     if (item.type === 'target') return item
     if (item.type === 'folder') {
       const found = findFirstTarget(item.children)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,26 +1,28 @@
+import type { Stats, TreeNode } from './types'
+
 const BASE = ''  // proxied by Vite dev server; empty for prod same-origin
 
 // Encode each path segment but preserve '/' separators so FastAPI's `path`
 // converter can match routes like /api/graph/{target_path:path}
-function encodePath(p) {
+function encodePath(p: string): string {
   return p.split('/').map(encodeURIComponent).join('/')
 }
 
-export async function fetchTargets() {
+export async function fetchTargets(): Promise<TreeNode[]> {
   const res = await fetch(`${BASE}/api/targets`)
   if (!res.ok) throw new Error(`Failed to fetch targets: ${res.status}`)
   return res.json()
 }
 
-export function graphUrl(targetPath, range = '3h') {
+export function graphUrl(targetPath: string, range = '3h'): string {
   return `${BASE}/api/graph/${encodePath(targetPath)}?range=${range}`
 }
 
-export function graphUrlWindow(targetPath, startTs, endTs) {
+export function graphUrlWindow(targetPath: string, startTs: number, endTs: number): string {
   return `${BASE}/api/graph/${encodePath(targetPath)}?start=${startTs}&end=${endTs}`
 }
 
-export async function fetchStats(targetPath, window = 300) {
+export async function fetchStats(targetPath: string, window = 300): Promise<Stats> {
   const res = await fetch(
     `${BASE}/api/targets/${encodePath(targetPath)}/stats?window=${window}`
   )

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -1,38 +1,55 @@
 import { useState, useEffect } from 'react'
-import { graphUrl, fetchStats } from '../api.js'
+import { graphUrl, fetchStats } from '../api'
+import type { TargetNode, Stats, TimeRange } from '../types'
 
-const RANGE_SECONDS = {
+const RANGE_SECONDS: Record<TimeRange, number> = {
   '3h':  3 * 3600,
   '2d':  2 * 24 * 3600,
   '1mo': 30 * 24 * 3600,
   '1y':  365 * 24 * 3600,
 }
 
-const RANGES = [
+const RANGES: Array<{ value: TimeRange; label: string }> = [
   { value: '3h',  label: '3 hours' },
   { value: '2d',  label: '2 days' },
   { value: '1mo', label: '1 month' },
   { value: '1y',  label: '1 year' },
 ]
 
-function GraphPanel({ target, range, label, imgKey, startTs, endTs, onZoom }) {
-  const url = graphUrl(target.path, range) + `&_k=${imgKey}`
-  const [drag, setDrag] = useState(null)
+interface DragState {
+  x0: number
+  x1: number
+  containerWidth: number
+}
 
-  function handleMouseDown(e) {
+interface GraphPanelProps {
+  target: TargetNode
+  range: TimeRange
+  label: string
+  imgKey: number
+  startTs: number
+  endTs: number
+  onZoom?: (startTs: number, endTs: number) => void
+}
+
+function GraphPanel({ target, range, label, imgKey, startTs, endTs, onZoom }: GraphPanelProps) {
+  const url = graphUrl(target.path, range) + `&_k=${imgKey}`
+  const [drag, setDrag] = useState<DragState | null>(null)
+
+  function handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const rect = e.currentTarget.getBoundingClientRect()
     const x = e.clientX - rect.left
     setDrag({ x0: x, x1: x, containerWidth: rect.width })
   }
 
-  function handleMouseMove(e) {
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
     if (!drag) return
     const rect = e.currentTarget.getBoundingClientRect()
     const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width))
-    setDrag((d) => ({ ...d, x1: x }))
+    setDrag((d) => (d ? { ...d, x1: x } : d))
   }
 
-  function handleMouseUp(e) {
+  function handleMouseUp() {
     if (!drag) return
     const { x0, x1, containerWidth } = drag
     setDrag(null)
@@ -71,10 +88,15 @@ function GraphPanel({ target, range, label, imgKey, startTs, endTs, onZoom }) {
   )
 }
 
-export default function GraphView({ target, onZoom }) {
+interface GraphViewProps {
+  target: TargetNode | null
+  onZoom: (startTs: number, endTs: number) => void
+}
+
+export default function GraphView({ target, onZoom }: GraphViewProps) {
   const [imgKey, setImgKey] = useState(0)
-  const [stats, setStats] = useState(null)
-  const [statsError, setStatsError] = useState(null)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [statsError, setStatsError] = useState<string | null>(null)
 
   // Reload all graphs when target changes
   useEffect(() => {
@@ -94,7 +116,7 @@ export default function GraphView({ target, onZoom }) {
     setStatsError(null)
     fetchStats(target.path)
       .then(setStats)
-      .catch((e) => setStatsError(e.message))
+      .catch((e: Error) => setStatsError(e.message))
   }, [target])
 
   if (!target) {
@@ -125,7 +147,7 @@ export default function GraphView({ target, onZoom }) {
               </span>
               <span className="stat">
                 <span className="stat-label">loss</span>
-                <span className={`stat-value ${stats.loss_pct > 0 ? 'loss-nonzero' : ''}`}>
+                <span className={`stat-value ${stats.loss_pct != null && stats.loss_pct > 0 ? 'loss-nonzero' : ''}`}>
                   {stats.loss_pct != null ? `${stats.loss_pct}%` : '—'}
                 </span>
               </span>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,21 @@
 import { useState } from 'react'
+import type { TreeNode, FolderNode, TargetNode } from '../types'
 
-function FolderNode({ node, activePath, onSelect, depth = 0 }) {
+interface FolderItemProps {
+  node: FolderNode
+  activePath: string | null
+  onSelect: (node: TargetNode) => void
+  depth?: number
+}
+
+interface TargetItemProps {
+  node: TargetNode
+  activePath: string | null
+  onSelect: (node: TargetNode) => void
+  depth?: number
+}
+
+function FolderItem({ node, activePath, onSelect, depth = 0 }: FolderItemProps) {
   const [open, setOpen] = useState(true)
 
   return (
@@ -17,7 +32,7 @@ function FolderNode({ node, activePath, onSelect, depth = 0 }) {
         <div className="folder-children">
           {node.children.map((child) =>
             child.type === 'folder' ? (
-              <FolderNode
+              <FolderItem
                 key={child.path}
                 node={child}
                 activePath={activePath}
@@ -25,7 +40,7 @@ function FolderNode({ node, activePath, onSelect, depth = 0 }) {
                 depth={depth + 1}
               />
             ) : (
-              <TargetNode
+              <TargetItem
                 key={child.path}
                 node={child}
                 activePath={activePath}
@@ -40,7 +55,7 @@ function FolderNode({ node, activePath, onSelect, depth = 0 }) {
   )
 }
 
-function TargetNode({ node, activePath, onSelect, depth = 0 }) {
+function TargetItem({ node, activePath, onSelect, depth = 0 }: TargetItemProps) {
   const isActive = activePath === node.path
   return (
     <button
@@ -53,7 +68,15 @@ function TargetNode({ node, activePath, onSelect, depth = 0 }) {
   )
 }
 
-export default function Sidebar({ tree, activePath, onSelect, loading, error }) {
+interface SidebarProps {
+  tree: TreeNode[] | null
+  activePath: string | null
+  onSelect: (node: TargetNode) => void
+  loading: boolean
+  error?: string | null
+}
+
+export default function Sidebar({ tree, activePath, onSelect, loading, error }: SidebarProps) {
   if (loading) return <div className="sidebar-status">Loading...</div>
   if (error) return <div className="sidebar-status sidebar-error">Error: {error}</div>
   if (!tree || tree.length === 0) return <div className="sidebar-status">No targets</div>
@@ -64,14 +87,14 @@ export default function Sidebar({ tree, activePath, onSelect, loading, error }) 
       <div className="sidebar-tree">
         {tree.map((node) =>
           node.type === 'folder' ? (
-            <FolderNode
+            <FolderItem
               key={node.path}
               node={node}
               activePath={activePath}
               onSelect={onSelect}
             />
           ) : (
-            <TargetNode
+            <TargetItem
               key={node.path}
               node={node}
               activePath={activePath}

--- a/frontend/src/components/ZoomView.tsx
+++ b/frontend/src/components/ZoomView.tsx
@@ -1,23 +1,38 @@
 import { useState, useEffect } from 'react'
-import { graphUrlWindow } from '../api.js'
+import { graphUrlWindow } from '../api'
+import type { TargetNode } from '../types'
 
-function tsToDatetimeLocal(ts) {
+interface ZoomViewProps {
+  target: TargetNode
+  startTs: number
+  endTs: number
+  onBack: () => void
+  onZoom: (startTs: number, endTs: number) => void
+}
+
+interface DragState {
+  x0: number
+  x1: number
+  containerWidth: number
+}
+
+function tsToDatetimeLocal(ts: number): string {
   const d = new Date(ts * 1000)
-  const pad = (n) => String(n).padStart(2, '0')
+  const pad = (n: number) => String(n).padStart(2, '0')
   return (
     `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
     `T${pad(d.getHours())}:${pad(d.getMinutes())}`
   )
 }
 
-function datetimeLocalToTs(s) {
+function datetimeLocalToTs(s: string): number {
   return Math.floor(new Date(s).getTime() / 1000)
 }
 
-export default function ZoomView({ target, startTs, endTs, onBack, onZoom }) {
+export default function ZoomView({ target, startTs, endTs, onBack, onZoom }: ZoomViewProps) {
   const [localStart, setLocalStart] = useState(startTs)
   const [localEnd, setLocalEnd] = useState(endTs)
-  const [drag, setDrag] = useState(null)
+  const [drag, setDrag] = useState<DragState | null>(null)
   const [imgKey, setImgKey] = useState(0)
 
   // Sync local state when props change (e.g. further zoom-in from drag)
@@ -27,7 +42,7 @@ export default function ZoomView({ target, startTs, endTs, onBack, onZoom }) {
     setImgKey((k) => k + 1)
   }, [startTs, endTs])
 
-  function handleStartChange(e) {
+  function handleStartChange(e: React.ChangeEvent<HTMLInputElement>) {
     const ts = datetimeLocalToTs(e.target.value)
     if (!isNaN(ts)) {
       setLocalStart(ts)
@@ -35,7 +50,7 @@ export default function ZoomView({ target, startTs, endTs, onBack, onZoom }) {
     }
   }
 
-  function handleEndChange(e) {
+  function handleEndChange(e: React.ChangeEvent<HTMLInputElement>) {
     const ts = datetimeLocalToTs(e.target.value)
     if (!isNaN(ts)) {
       setLocalEnd(ts)
@@ -49,17 +64,17 @@ export default function ZoomView({ target, startTs, endTs, onBack, onZoom }) {
     onZoom(Math.floor(center - half), Math.floor(center + half))
   }
 
-  function handleMouseDown(e) {
+  function handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
     const rect = e.currentTarget.getBoundingClientRect()
     const x = e.clientX - rect.left
     setDrag({ x0: x, x1: x, containerWidth: rect.width })
   }
 
-  function handleMouseMove(e) {
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
     if (!drag) return
     const rect = e.currentTarget.getBoundingClientRect()
     const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width))
-    setDrag((d) => ({ ...d, x1: x }))
+    setDrag((d) => (d ? { ...d, x1: x } : d))
   }
 
   function handleMouseUp() {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './App.css'
-import App from './App.jsx'
+import App from './App'
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -1,29 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import App from '../App.jsx'
-import { fetchTargets, fetchStats } from '../api.js'
+import App from '../App'
+import { fetchTargets, fetchStats } from '../api'
+import type { TargetNode } from '../types'
 
 // Keep graphUrl / graphUrlWindow as real implementations; only mock the fetch calls.
-vi.mock('../api.js', async (importActual) => {
-  const actual = await importActual()
+vi.mock('../api', async (importActual) => {
+  const actual = await importActual<typeof import('../api')>()
   return { ...actual, fetchTargets: vi.fn(), fetchStats: vi.fn() }
 })
 
-const TARGET = { type: 'target', path: '8.8.8.8', name: 'Google DNS', host: '8.8.8.8' }
-const TARGET2 = { type: 'target', path: '1.1.1.1', name: 'Cloudflare DNS', host: '1.1.1.1' }
+const TARGET: TargetNode = { type: 'target', path: '8.8.8.8', name: 'Google DNS', host: '8.8.8.8' }
+const TARGET2: TargetNode = { type: 'target', path: '1.1.1.1', name: 'Cloudflare DNS', host: '1.1.1.1' }
 const FOLDER_TREE = [{
-  type: 'folder', path: 'CDNs', name: 'CDNs',
-  children: [{ type: 'target', path: 'CDNs/Cloudflare', name: 'Cloudflare', host: '1.1.1.1' }],
+  type: 'folder' as const, path: 'CDNs', name: 'CDNs',
+  children: [{ type: 'target' as const, path: 'CDNs/Cloudflare', name: 'Cloudflare', host: '1.1.1.1' }],
 }]
 
 beforeEach(() => {
   vi.resetAllMocks()
-  fetchStats.mockResolvedValue({ median_ms: 12.3, loss_pct: 0, sample_count: 10 })
+  vi.mocked(fetchStats).mockResolvedValue({ median_ms: 12.3, loss_pct: 0, sample_count: 10 })
 })
 
 // Trigger a drag on the first .graph-drag-overlay large enough to fire onZoom.
-function dragOnFirstOverlay(container) {
-  const overlay = container.querySelector('.graph-drag-overlay')
+function dragOnFirstOverlay(container: HTMLElement) {
+  const overlay = container.querySelector('.graph-drag-overlay') as HTMLElement
   overlay.getBoundingClientRect = vi.fn().mockReturnValue({
     left: 0, width: 500, top: 0, right: 500, bottom: 100, height: 100,
   })
@@ -34,26 +35,26 @@ function dragOnFirstOverlay(container) {
 
 describe('App initial load', () => {
   it('auto-selects the first flat target', async () => {
-    fetchTargets.mockResolvedValue([TARGET])
+    vi.mocked(fetchTargets).mockResolvedValue([TARGET])
     render(<App />)
     // Graph header shows the selected target name
     expect(await screen.findByText('Google DNS', { selector: '.graph-target-name' })).toBeInTheDocument()
   })
 
   it('auto-selects the first target inside a folder', async () => {
-    fetchTargets.mockResolvedValue(FOLDER_TREE)
+    vi.mocked(fetchTargets).mockResolvedValue(FOLDER_TREE)
     render(<App />)
     expect(await screen.findByText('Cloudflare', { selector: '.graph-target-name' })).toBeInTheDocument()
   })
 
   it('shows an error in the sidebar when the fetch fails', async () => {
-    fetchTargets.mockRejectedValue(new Error('timeout'))
+    vi.mocked(fetchTargets).mockRejectedValue(new Error('timeout'))
     render(<App />)
     expect(await screen.findByText(/timeout/)).toBeInTheDocument()
   })
 
   it('renders GraphView (not ZoomView) on initial load', async () => {
-    fetchTargets.mockResolvedValue([TARGET])
+    vi.mocked(fetchTargets).mockResolvedValue([TARGET])
     render(<App />)
     await screen.findByText('Google DNS', { selector: '.graph-target-name' })
     expect(screen.queryByRole('button', { name: /Back/ })).not.toBeInTheDocument()
@@ -62,7 +63,7 @@ describe('App initial load', () => {
 
 describe('App zoom state transitions', () => {
   async function renderAndZoom() {
-    fetchTargets.mockResolvedValue([TARGET])
+    vi.mocked(fetchTargets).mockResolvedValue([TARGET])
     const utils = render(<App />)
     await screen.findByText('Google DNS', { selector: '.graph-target-name' })
     dragOnFirstOverlay(utils.container)
@@ -82,7 +83,7 @@ describe('App zoom state transitions', () => {
   })
 
   it('clears zoom state when a sidebar target is selected', async () => {
-    fetchTargets.mockResolvedValue([TARGET, TARGET2])
+    vi.mocked(fetchTargets).mockResolvedValue([TARGET, TARGET2])
     const { container } = render(<App />)
     await screen.findByText('Google DNS', { selector: '.graph-target-name' })
     dragOnFirstOverlay(container)

--- a/frontend/src/test/Sidebar.test.tsx
+++ b/frontend/src/test/Sidebar.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import Sidebar from '../components/Sidebar.jsx'
+import Sidebar from '../components/Sidebar'
+import type { TargetNode, FolderNode } from '../types'
 
-const T1 = { type: 'target', path: '8.8.8.8',  name: 'Google DNS' }
-const T2 = { type: 'target', path: '1.1.1.1',  name: 'Cloudflare DNS' }
-const FOLDER = {
+const T1: TargetNode = { type: 'target', path: '8.8.8.8',  name: 'Google DNS', host: '8.8.8.8' }
+const T2: TargetNode = { type: 'target', path: '1.1.1.1',  name: 'Cloudflare DNS', host: '1.1.1.1' }
+const FOLDER: FolderNode = {
   type: 'folder', path: 'CDNs', name: 'CDNs',
-  children: [{ type: 'target', path: 'CDNs/Cloudflare', name: 'Cloudflare' }],
+  children: [{ type: 'target', path: 'CDNs/Cloudflare', name: 'Cloudflare', host: '1.1.1.1' }],
 }
 
 describe('Sidebar loading / error / empty states', () => {

--- a/frontend/src/test/ZoomView.test.tsx
+++ b/frontend/src/test/ZoomView.test.tsx
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import ZoomView from '../components/ZoomView.jsx'
+import ZoomView from '../components/ZoomView'
+import type { TargetNode } from '../types'
 
-const TARGET = { path: 'CDNs/Cloudflare', name: 'Cloudflare', host: '1.1.1.1' }
+const TARGET: TargetNode = { type: 'target', path: 'CDNs/Cloudflare', name: 'Cloudflare', host: '1.1.1.1' }
 
-function renderZoom({ startTs = 1000, endTs = 2000, onBack, onZoom } = {}) {
+interface RenderZoomOptions {
+  startTs?: number
+  endTs?: number
+  onBack?: () => void
+  onZoom?: (startTs: number, endTs: number) => void
+}
+
+function renderZoom({ startTs = 1000, endTs = 2000, onBack, onZoom }: RenderZoomOptions = {}) {
   onBack = onBack ?? vi.fn()
   onZoom = onZoom ?? vi.fn()
   const result = render(
@@ -14,8 +22,8 @@ function renderZoom({ startTs = 1000, endTs = 2000, onBack, onZoom } = {}) {
 }
 
 // Mock getBoundingClientRect on the drag overlay so containerWidth is non-zero.
-function mockOverlay(container, width = 500) {
-  const overlay = container.querySelector('.graph-drag-overlay')
+function mockOverlay(container: HTMLElement, width = 500) {
+  const overlay = container.querySelector('.graph-drag-overlay') as HTMLElement
   overlay.getBoundingClientRect = vi.fn().mockReturnValue({
     left: 0, width, top: 0, right: width, bottom: 100, height: 100,
   })
@@ -32,8 +40,8 @@ describe('ZoomView rendering', () => {
   it('renders a graph image with the windowed URL', () => {
     const { container } = renderZoom({ startTs: 1000, endTs: 2000 })
     const img = container.querySelector('img')
-    expect(img.getAttribute('src')).toMatch(/start=1000/)
-    expect(img.getAttribute('src')).toMatch(/end=2000/)
+    expect(img?.getAttribute('src')).toMatch(/start=1000/)
+    expect(img?.getAttribute('src')).toMatch(/end=2000/)
   })
 })
 

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { graphUrl, graphUrlWindow, fetchTargets, fetchStats } from '../api.js'
+import { graphUrl, graphUrlWindow, fetchTargets, fetchStats } from '../api'
 
 describe('graphUrl', () => {
   it('builds a simple target URL with default range', () => {
@@ -32,7 +32,7 @@ describe('fetchTargets', () => {
   })
 
   it('returns parsed JSON on success', async () => {
-    const targets = [{ path: '8.8.8.8', name: '8.8.8.8' }]
+    const targets = [{ type: 'target' as const, path: '8.8.8.8', name: '8.8.8.8', host: '8.8.8.8' }]
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(targets),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    setupFiles: ['./src/test/setup.js'],
+    setupFiles: ['./src/test/setup.ts'],
     globals: true,
   },
 })


### PR DESCRIPTION
## Summary

#8 was missing a commit. This PR adds the commit so that the typescript migration actually contains typescript. 

## Test plan

- [x] `just test-frontend` passes (34/34)
- [x] `cd frontend && npx tsc --noEmit` exits clean